### PR TITLE
Nim 2.x support and replace std/httpclient with puppy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,30 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
-  build:
+  unit:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        nim: ['2.0.x', '2.2.x', 'devel']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install libcurl
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
+      - uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: ${{ matrix.nim }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies
+        run: nimble install -dy
+      - name: Run unit tests
+        run: nimble test
+
+  integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: docker compose up and test
-        run: |
-          make docker-test
+        run: make docker-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         nim: ['2.0.x', '2.2.x', 'devel']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install libcurl
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
       - uses: jiro4989/setup-nim-action@v2
@@ -25,6 +25,6 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: docker compose up and test
         run: make docker-test

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,23 @@
-.RECIPEPREFIX +=
-
 .PHONY: format
 format:
-  nimfmt -i src/webdavclient.nim tests/test_webdav.nim
+	nimfmt -i src/webdavclient.nim tests/test_webdav.nim tests/test_parsing.nim
 
 
 .PHONY: develop
 develop:
-  nimble develop --verbose
+	nimble develop --verbose
 
 
 .PHONY: install
 install:
-  nimble install -y
+	nimble install -y
+
+
+.PHONY: test
+test:
+	nimble test
+
 
 .PHONY: docker-test
 docker-test:
-  docker-compose \
-    -f tests/docker-compose.test.yml \
-    -p nim-webdavclient-test \
-    up \
-    --exit-code-from sut \
-    --force-recreate
+	docker compose -f tests/docker-compose.test.yml -p nim-webdavclient-test up --exit-code-from sut --force-recreate

--- a/README.md
+++ b/README.md
@@ -6,70 +6,72 @@
 This is an implementation for some of the basic
 operations to communicate with a WebDAV server using Nim.
 
+The client is **synchronous** and is built on top of
+[puppy](https://github.com/treeform/puppy). On Linux puppy uses libcurl, so
+install it (e.g. `libcurl4-openssl-dev`) to build; macOS and Windows use the
+native HTTP stack and need no extra dependency.
+
 
 Example usage:
 
 ```nim
-import webdavclient, asyncdispatch, tables, options
+import webdavclient, tables
 
 # Only Basic auth is currently supported. Make sure you're
-# connecting over ssl
+# connecting over ssl.
 
-let wd = newAsyncWebDAV(
-  address="https://dav.example.com",
-  username="username",
-  password="password"
+let wd = newWebDAV(
+  address = "https://dav.example.com",
+  username = "username",
+  password = "password"
 )
 
-# Get props (propname request)
-let possible_props = waitFor wd.props(
-  "/",
-  depth=ZERO
-)
+# Get the property names available for a resource (propname request)
+let possibleProps = wd.props("/", depth = ZERO)
 
-for url, props in possible_props["/"]:
-  echo(url, props)
+for href, names in possibleProps:
+  echo href, ": ", names
 
-# List files
-# Default webdav properties don't require a namespace
-let t = waitFor wd.ls(
+# List files.
+# Default webdav properties don't require a namespace.
+let t = wd.ls(
   "/",
-  props=some(@[
+  @[
     "getcontentlength",
     "getlastmodified",
-	"creationdate",
-	"getcontenttype",
-	"nc:has-preview",
-	"oc:favorite",
-  ]),
-  namespaces=some(@[
+    "creationdate",
+    "getcontenttype",
+    "nc:has-preview",
+    "oc:favorite",
+  ],
+  namespaces = @[
     ("oc", "http://owncloud.org/ns"),
     ("nc", "http://nextcloud.org/ns")
-  ]),
-  depth=ONE
+  ],
+  depth = ONE
 )
 
 for url, prop in t.pairs:
   echo(url)
   for pname, pval in prop.pairs:
-    echo(" - " , pname, ": ", pval)
+    echo(" - ", pname, ": ", pval)
   echo("---")
 
-# Downlaod a file
-waitFor wd.download(path="files/example.md", destination="/home/me/example.md")
+# Download a file (buffered in memory, then written to disk)
+wd.download(path = "files/example.md", destination = "/home/me/example.md")
 
 # Upload a file
-waitFor wd.upload(filepath="files/example.md", destination="/home/me/example.md")
+wd.upload(filepath = "files/example.md", destination = "/home/me/example.md")
 
 # Delete a file
-waitFor wd.rm("files/example.md")
+wd.rm("files/example.md")
 
 # Create a collection (directory)
-waitFor wd.mkdir("files/new/")
+wd.mkdir("files/new/")
 
 # Move a file
-waitFor wd.mv(path="files/example.md", destination="files/new/example.md", overwrite=true)
+wd.mv(path = "files/example.md", destination = "files/new/example.md", overwrite = true)
 
 # Copy a file
-waitFor wd.cp(path="files/new/example.md", destination="files/example.md", overwrite=true)
+wd.cp(path = "files/new/example.md", destination = "files/example.md", overwrite = true)
 ```

--- a/src/webdavclient.nim
+++ b/src/webdavclient.nim
@@ -1,124 +1,156 @@
 ## A WebDAV Client for Nim.
+##
+## Built on top of `puppy <https://github.com/treeform/puppy>`_, so the API is
+## synchronous. On Linux puppy needs libcurl available at build/run time;
+## macOS and Windows use the native HTTP stack.
 
-import options
-from sequtils import zip
-from strutils import replace, split, parseInt
-import strtabs, tables, base64, xmlparser, xmltree, asyncfile, os
-import uri, asyncdispatch, httpClient
-
-
-const REDIRECTS = @[HttpCode(301), HttpCode(302), HttpCode(307), HttpCode(308)]
+import std/[base64, strutils, tables, strtabs, xmlparser, xmltree, os, uri]
+import puppy
 
 type
-  OperationFailed* = object of Exception
-    code: HttpCode
+  OperationFailed* = object of CatchableError
+    ## Raised when the server (or a local check) reports a failed operation.
+    ## `code` carries the HTTP status code (0 for local failures).
+    code*: int
 
-type
-  filesTable = Table[string, string]
-  header = tuple
-    name: string
-    value: string
-  namespace = tuple
+  FilesTable* = Table[string, string]
+
+  Namespace* = tuple
     name: string
     url: string
 
-type
   Depth* = enum
     ZERO = "0"
     ONE = "1"
     INF = "infinity"
 
+  WebDAV* = ref object
+    address*: string
+    path*: string
+    timeout*: float32
+    username: string
+    password: string
 
-proc operationFailed(msg: string, code: HttpCode) {.noreturn.} =
-  ## raises an OperationFailed exception with message `msg`.
-  var e: ref OperationFailed
-  new(e)
-  e.msg = msg
+
+proc operationFailed(msg: string, code: int) {.noreturn.} =
+  ## Raise an `OperationFailed` carrying the HTTP status `code`.
+  var e = newException(OperationFailed, msg)
   e.code = code
   raise e
 
 
 proc operationFailed(msg: string) {.noreturn.} =
-  var e: ref OperationFailed
-  new(e)
-  e.msg = msg
-  raise e
+  raise newException(OperationFailed, msg)
 
 
-type AsyncWebDAV* = ref object of RootObj
-  client*: AsyncHttpClient
-  path*: string
-  address*: string
-  username: string
-  password: string
+proc is2xx(code: int): bool =
+  code >= 200 and code < 300
 
 
-proc newAsyncWebDAV*(
+proc newWebDAV*(
   address: string,
   username: string,
   password: string,
-  path: string = ""
-): AsyncWebDAV =
-  ## Create an async webdav client. Only Basic auth is supported for now.
-  let fulladdr = parseUri(address) / path
-  let client = newAsyncHttpClient(maxRedirects = 0)
-
-  AsyncWebDAV(
-    client: client,
+  path: string = "",
+  timeout: float32 = 60,
+): WebDAV =
+  ## Create a webdav client. Only Basic auth is supported for now.
+  WebDAV(
     path: path,
-    address: $fulladdr,
+    address: $(parseUri(address) / path),
     username: username,
     password: password,
+    timeout: timeout,
   )
 
 
 proc request(
-  wd: AsyncWebDAV,
+  wd: WebDAV,
   path: string,
-  httpMethod: string,
+  verb: string,
   body: string = "",
-  headers: Option[seq[header]] = none(seq[header]),
-): Future[AsyncResponse] {.async.} =
+  extraHeaders: seq[(string, string)] = @[],
+): Response =
+  ## Issue a request to `path` (joined onto the client address) with Basic auth.
+  ## puppy follows redirects and keeps the custom verb across them.
+  var headers: HttpHeaders
+  headers["Authorization"] = "Basic " & base64.encode(wd.username & ":" & wd.password)
+  for (k, v) in extraHeaders:
+    headers[k] = v
+  if body.len > 0 and "Content-Type" notin headers:
+    headers["Content-Type"] = "application/xml; charset=utf-8"
 
-  let auth = "Basic " & base64.encode(
-    wd.username & ":" & wd.password
-  )
-
-  wd.client.headers = newHttpHeaders({"Authorization": auth})
-
-  if isSome(headers):
-    for (h, v) in headers.get:
-      wd.client.headers[h] = v
-
-  return await wd.client.request(
+  let req = newRequest(
     $(parseUri(wd.address) / path),
-    httpMethod = httpMethod,
-    body = body
+    verb = verb,
+    headers = headers,
+    timeout = wd.timeout,
   )
+  req.body = body
+  result = fetch(req)
 
 
 proc getDefaultXmlAttrs(): XmlAttributes =
   {"xmlns": "DAV:"}.toXmlAttributes
 
 
-proc shouldRedirect(resp: AsyncResponse): bool =
-  return resp.code in REDIRECTS and resp.headers.hasKey("location")
+proc parsePropfindList(
+  body: string, stripPrefix: string
+): Table[string, FilesTable] =
+  ## Parse a PROPFIND multistatus response into a table of (relative href ->
+  ## its properties). `stripPrefix` is removed from the start of each href.
+  let node = parseXml(body)
+  let ns = node.tag.split(":")[0] & ":"
+  result = initTable[string, FilesTable]()
+
+  for item in node:
+    let href = item.child(ns & "href")
+    if href == nil:
+      continue
+
+    var propsTable: FilesTable
+    let propstat = item.child(ns & "propstat")
+    if propstat != nil:
+      for prop in propstat.findAll(ns & "prop"):
+        for p in prop:
+          propsTable[p.tag] = p.innerText
+
+    var key = href.innerText
+    if stripPrefix.len > 0:
+      key = key.replace(stripPrefix, "")
+    result[key] = propsTable
 
 
-proc locationHeader(resp: AsyncResponse): string =
-  return resp.headers["location"]
+proc parsePropNames(body: string): Table[string, seq[string]] =
+  ## Parse a `propname` PROPFIND response into a table of (href -> property
+  ## names available for that resource).
+  let node = parseXml(body)
+  let ns = node.tag.split(":")[0] & ":"
+  result = initTable[string, seq[string]]()
+
+  for response in node.findAll(ns & "response"):
+    let href = response.child(ns & "href")
+    if href == nil:
+      continue
+
+    var names: seq[string]
+    for propstat in response.findAll(ns & "propstat"):
+      for prop in propstat.findAll(ns & "prop"):
+        for p in prop:
+          names.add(p.tag.replace(ns, ""))
+    result[href.innerText] = names
 
 
 proc ls*(
-  wd: AsyncWebDAV,
+  wd: WebDAV,
   path: string,
-  props: Option[seq[string]] = none(seq[string]),
-  namespaces: Option[seq[namespace]] = none(seq[namespace]),
+  props: seq[string] = @[],
+  namespaces: seq[Namespace] = @[],
   depth: Depth = ONE,
-): Future[Table[string, filesTable]] {.async.} =
+): Table[string, FilesTable] =
   ## Returns a table of relative urls (of files and directories)
   ## and their properties at specified path (or only of the specified
-  ## path if `depth` is set to `ZERO`.
+  ## path if `depth` is set to `ZERO`).
   ##
   ## `DAV:` is the default namespace, meaning dav properties
   ## can be provided directly without a namespace.
@@ -127,26 +159,22 @@ proc ls*(
   ## ```nim
   ## wd.ls(
   ##   "/",
-  ##   some(@["getcontentlength", "getlastmodified"]),
-  ##   depth=ONE
+  ##   @["getcontentlength", "getlastmodified"],
+  ##   depth = ONE
   ## )
   ## ```
   ##
   ## If no props are provided, no request body will be sent.
-
-  var propNode = newElement("prop")
-  var nsAttrs = getDefaultXmlAttrs()
-
-  if isSome(namespaces):
-    for (ns, url) in namespaces.get:
-      nsAttrs["xmlns:" & ns] = url
-
   var reqBody = ""
 
-  if isSome(props):
-    for p in props.get:
-      let pNode = newElement(p)
-      propNode.add(pNode)
+  if props.len > 0:
+    var nsAttrs = getDefaultXmlAttrs()
+    for (ns, url) in namespaces:
+      nsAttrs["xmlns:" & ns] = url
+
+    var propNode = newElement("prop")
+    for p in props:
+      propNode.add(newElement(p))
 
     var reqXml = newElement("propfind")
     reqXml.attrs = nsAttrs
@@ -154,231 +182,148 @@ proc ls*(
 
     reqBody = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" & $reqXml
 
-  let resp = await wd.request(
+  let resp = wd.request(
     path,
-    httpMethod = "PROPFIND",
+    verb = "PROPFIND",
     body = reqBody,
-    headers = some(@[("Depth", $depth)])
+    extraHeaders = @[("Depth", $depth)],
   )
 
-  if resp.shouldRedirect:
-    let newPath = resp.locationHeader().replace(wd.address, "")
-    return await wd.ls(
-      path = newPath,
-      props = props,
-      namespaces = namespaces,
-      depth = depth,
-    )
-
-  if resp.code != HttpCode(207):
+  if resp.code != 207:
     operationFailed(
-      "Got unexpected status " & resp.status & " with response from server:\n" &
-      await resp.body, resp.code
+      "Got unexpected status " & $resp.code &
+        " with response from server:\n" & resp.body,
+      resp.code,
     )
 
-  let body = await resp.body
-  let node: XmlNode = parseXml(body)
-  var files = initTable[string, filesTable]()
-  var hrefs = newSeq[string]()
-  var propsTables = newSeq[filesTable]()
+  result = parsePropfindList(resp.body, wd.path)
 
-  let NS = node.tag.split(":")[0] & ":"
-
-  for item in node:
-    let href = item.child(NS & "href")
-    let props = item.child(NS & "propstat")
-    hrefs.add(href.innerText.replace(wd.path, ""))
-
-    var propsTable: filesTable
-    for prop in props.findAll(NS & "prop"):
-      for p in prop:
-        propsTable[p.tag] = p.innerText
-
-    propsTables.add(propsTable)
-
-  for pairs in zip(hrefs, propsTables):
-    let (href, props) = pairs
-    files[href] = props
-
-  return files
 
 proc props*(
-  wd: AsyncWebDAV,
+  wd: WebDAV,
   path: string,
-  namespaces: Option[seq[namespace]] = none(seq[namespace]),
+  namespaces: seq[Namespace] = @[],
   depth: Depth = ONE,
-): Future[Table[string, seq[string]]] {.async.} =
-  var reqXml = newElement("propfind")
-
+): Table[string, seq[string]] =
+  ## Returns the property names available for each resource at `path`
+  ## (a `propname` PROPFIND request).
   var nsAttrs = getDefaultXmlAttrs()
+  for (ns, url) in namespaces:
+    nsAttrs["xmlns:" & ns] = url
 
-  if isSome(namespaces):
-    for (ns, url) in namespaces.get:
-      nsAttrs["xmlns:" & ns] = url
-
+  var reqXml = newElement("propfind")
   reqXml.attrs = nsAttrs
   reqXml.add(newElement("propname"))
 
   let reqBody = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" & $reqXml
 
-  let resp = await wd.request(
+  let resp = wd.request(
     path,
-    httpMethod = "PROPFIND",
+    verb = "PROPFIND",
     body = reqBody,
-    headers = some(
-      @[("Depth", $depth)]
-    )
+    extraHeaders = @[("Depth", $depth)],
   )
 
-  if resp.shouldRedirect:
-    let newPath = resp.locationHeader().replace(wd.address, "")
-    return await wd.props(
-      path = newPath,
-      namespaces = namespaces,
-      depth = depth,
-    )
-
-  if resp.code != HttpCode(207):
+  if resp.code != 207:
     operationFailed(
-      "Got unexpected response from server:\n" & await resp.body, resp.code
+      "Got unexpected response from server:\n" & resp.body, resp.code
     )
 
-  let body = await resp.body
-  let node: XmlNode = parseXml(body)
-
-  var properties = initTable[string, seq[string]]()
-
-  let NS = node.tag.split(":")[0] & ":"
-
-  for response in node.findAll(NS & "response"):
-    let href = response.child(NS & "href")
-    properties[href.innerText] = @[]
-    let props = response.child(NS & "propstat")
-    for pstat in response:
-      for prop in pstat.findAll(NS & "prop"):
-        for p in prop:
-          let tag = p.tag.replace(NS, "")
-          properties[href.innerText].add(tag)
-
-  return properties
+  result = parsePropNames(resp.body)
 
 
 proc download*(
-  wd: AsyncWebDAV,
+  wd: WebDAV,
   path: string,
   destination: string,
-) {.async.} =
-  let resp = await wd.request(
-    path,
-    httpMethod = "GET",
-  )
+) =
+  ## Download the resource at `path` to a local file. The whole body is
+  ## buffered in memory before being written.
+  let resp = wd.request(path, verb = "GET")
 
-  if resp.code != HttpCode(200):
-    operationFailed(await resp.body, resp.code)
+  if resp.code != 200:
+    operationFailed(resp.body, resp.code)
 
-  var output = openAsync(destination, fmWrite)
-
-  if not isNil(output):
-    await output.writeFromStream(resp.bodyStream)
-    output.close()
+  writeFile(destination, resp.body)
 
 
 proc upload*(
-  wd: AsyncWebDAV,
+  wd: WebDAV,
   filepath: string,
   destination: string,
-) {.async.} =
+) =
+  ## Upload a local file to `destination`.
   if not fileExists(filepath):
     operationFailed("File \"" & filepath & "\" not found")
 
-  var strm = openAsync(filepath, fmRead)
-  let reqBody = await strm.readAll()
+  let resp = wd.request(destination, verb = "PUT", body = readFile(filepath))
 
-  let resp = await wd.request(
-    destination,
-    httpMethod = "PUT",
-    body = reqBody,
-  )
-
-  if resp.code != HttpCode(201):
-    operationFailed(await resp.body, resp.code)
+  if not is2xx(resp.code):
+    operationFailed(resp.body, resp.code)
 
 
 proc mkdir*(
-  wd: AsyncWebDAV,
+  wd: WebDAV,
   path: string,
-) {.async.} =
-  let resp = await wd.request(
-    path,
-    httpMethod = "MKCOL",
-  )
+) =
+  ## Create a collection (directory).
+  let resp = wd.request(path, verb = "MKCOL")
 
-  if resp.code != HttpCode(201):
-    operationFailed(await resp.body, resp.code)
+  if resp.code notin [200, 201]:
+    operationFailed(resp.body, resp.code)
 
 
 proc rm*(
-  wd: AsyncWebDAV,
+  wd: WebDAV,
   path: string,
-) {.async.} =
+) =
   ## Delete a file or directory. If path is a directory,
   ## all resources within will be deleted recursively.
-  let resp = await wd.request(
-    path,
-    httpMethod = "DELETE",
-  )
+  let resp = wd.request(path, verb = "DELETE")
 
-  if resp.code != HttpCode(204):
-    operationFailed(await resp.body, resp.code)
+  if resp.code notin [200, 204]:
+    operationFailed(resp.body, resp.code)
 
 
 proc mv*(
-  wd: AsyncWebDAV,
+  wd: WebDAV,
   path: string,
   destination: string,
   overwrite: bool = false,
   depth: Depth = INF,
-) {.async.} =
+) =
   ## Move a resource from one location to another.
-  var overwriteValue = "F"
-  if overwrite:
-    overwriteValue = "T"
-
-  let resp = await wd.request(
+  let resp = wd.request(
     path,
-    httpMethod = "MOVE",
-    headers = some(
-      @[("Destination", $(parseUri(wd.address) / destination)),
-        ("Overwrite", overwriteValue),
-        ("Depth", $depth)]
-    )
+    verb = "MOVE",
+    extraHeaders = @[
+      ("Destination", $(parseUri(wd.address) / destination)),
+      ("Overwrite", if overwrite: "T" else: "F"),
+      ("Depth", $depth),
+    ],
   )
 
-  if resp.code != HttpCode(204) and resp.code != HttpCode(201):
-    operationFailed(await resp.body, resp.code)
+  if resp.code notin [201, 204]:
+    operationFailed(resp.body, resp.code)
 
 
 proc cp*(
-  wd: AsyncWebDAV,
+  wd: WebDAV,
   path: string,
   destination: string,
   overwrite: bool = false,
   depth: Depth = INF,
-) {.async.} =
+) =
   ## Copy a resource to another location.
-  var overwriteValue = "F"
-  if overwrite:
-    overwriteValue = "T"
-
-  let resp = await wd.request(
+  let resp = wd.request(
     path,
-    httpMethod = "COPY",
-    headers = some(
-      @[("Destination", $(parseUri(wd.address) / destination)),
-        ("Overwrite", overwriteValue),
-        ("Depth", $depth)]
-    )
+    verb = "COPY",
+    extraHeaders = @[
+      ("Destination", $(parseUri(wd.address) / destination)),
+      ("Overwrite", if overwrite: "T" else: "F"),
+      ("Depth", $depth),
+    ],
   )
 
-  if resp.code != HttpCode(204) and resp.code != HttpCode(201):
-    operationFailed(await resp.body, resp.code)
+  if resp.code notin [201, 204]:
+    operationFailed(resp.body, resp.code)

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -1,12 +1,14 @@
-version: "3.7"
-
 services:
   sut:
-    image: nimlang/nim:1.0.0-regular
+    image: nimlang/nim:2.2.0
     stdin_open: true
     working_dir: /usr/src/app
     tty: true
-    command: nimble test -Y
+    command: >
+      sh -c "apt-get update -qq
+      && apt-get install -y -qq libcurl4-openssl-dev
+      && sleep 5
+      && nimble integration -y"
     volumes:
       - ../:/usr/src/app
     depends_on:

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -5,7 +5,8 @@ services:
     working_dir: /usr/src/app
     tty: true
     command: >
-      sh -c "apt-get update -qq
+      sh -c "git config --global --add safe.directory /usr/src/app
+      && apt-get update -qq
       && apt-get install -y -qq libcurl4-openssl-dev
       && sleep 5
       && nimble integration -y"

--- a/tests/test_parsing.nim
+++ b/tests/test_parsing.nim
@@ -1,0 +1,90 @@
+# Unit tests for the pure XML parsing helpers. These need no WebDAV server.
+# We `include` the module so we can reach its (private) parse procs.
+
+import std/[unittest, tables]
+
+include "../src/webdavclient.nim"
+
+const propfindListBody = """<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:">
+  <D:response>
+    <D:href>/files/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:getlastmodified>Mon, 01 Jan 2024 00:00:00 GMT</D:getlastmodified>
+        <D:resourcetype><D:collection/></D:resourcetype>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+  <D:response>
+    <D:href>/files/example.md</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:getcontentlength>34</D:getcontentlength>
+        <D:getcontenttype>text/markdown</D:getcontenttype>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>"""
+
+const propNamesBody = """<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:getcontenttype/>
+        <d:supportedlock/>
+        <d:lockdiscovery/>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>"""
+
+suite "parsePropfindList":
+  test "extracts hrefs and their properties":
+    let files = parsePropfindList(propfindListBody, "")
+    check files.len == 2
+    check files.hasKey("/files/")
+    check files.hasKey("/files/example.md")
+    check files["/files/example.md"]["D:getcontentlength"] == "34"
+    check files["/files/example.md"]["D:getcontenttype"] == "text/markdown"
+    check files["/files/"]["D:resourcetype"] == ""
+
+  test "strips the given prefix from hrefs":
+    let files = parsePropfindList(propfindListBody, "/files")
+    check files.hasKey("/")
+    check files.hasKey("/example.md")
+    check not files.hasKey("/files/")
+
+  test "handles a response with no propstat":
+    const body = """<?xml version="1.0"?>
+<D:multistatus xmlns:D="DAV:">
+  <D:response><D:href>/lonely.txt</D:href></D:response>
+</D:multistatus>"""
+    let files = parsePropfindList(body, "")
+    check files.hasKey("/lonely.txt")
+    check files["/lonely.txt"].len == 0
+
+suite "parsePropNames":
+  test "collects property names with the namespace prefix stripped":
+    let props = parsePropNames(propNamesBody)
+    check props.hasKey("/")
+    check "supportedlock" in props["/"]
+    check "lockdiscovery" in props["/"]
+    check "getcontenttype" in props["/"]
+    check "resourcetype" in props["/"]
+    check props["/"].len == 4
+
+suite "is2xx":
+  test "classifies status codes":
+    check is2xx(200)
+    check is2xx(204)
+    check is2xx(299)
+    check not is2xx(199)
+    check not is2xx(300)
+    check not is2xx(404)

--- a/tests/test_webdav.nim
+++ b/tests/test_webdav.nim
@@ -1,41 +1,45 @@
-import webdavclient, asyncdispatch, tables, options, os, streams
+# Integration test. Requires a live WebDAV server reachable at http://webdav
+# with Basic auth admin/password (see tests/docker-compose.test.yml).
+# Run with: nimble integration
+
+import webdavclient
+import std/[tables, os]
 
 when isMainModule:
-  let wd = newAsyncWebDAV(
+  let wd = newWebDAV(
     address = "http://webdav",
     username = "admin",
     password = "password",
   )
 
   # Make directory
-  waitFor wd.mkdir(path = "files/")
+  wd.mkdir(path = "files/")
 
   # This will fail because directory already exists
   doAssertRaises(OperationFailed):
-    waitFor wd.mkdir(path = "files/")
+    wd.mkdir(path = "files/")
 
   # Upload
-  waitFor wd.upload(
+  wd.upload(
     filepath = "tests/example.md",
     destination = "files/example.md"
   )
 
-  # File not found
+  # File not found (local)
   doAssertRaises(OperationFailed):
-    waitFor wd.upload(
+    wd.upload(
       filepath = "tests/does_not_exist.md",
       destination = "files/example.md"
     )
 
-  # File already exists
-  doAssertRaises(OperationFailed):
-    waitFor wd.upload(
-      filepath = "tests/example.md",
-      destination = "files/example.md"
-    )
+  # Re-uploading to an existing path overwrites it and succeeds (valid WebDAV).
+  wd.upload(
+    filepath = "tests/example.md",
+    destination = "files/example.md"
+  )
 
   # Download
-  waitFor wd.download(
+  wd.download(
     path = "files/example.md",
     destination = "/tmp/example.md"
   )
@@ -43,45 +47,42 @@ when isMainModule:
   # File exists
   assert fileExists("/tmp/example.md")
 
-  var fs = newFileStream("/tmp/example.md", fmRead)
-  let content = fs.readAll()
+  let content = readFile("/tmp/example.md")
   assert content == """# Example
 
 This is an example file.
 """
 
   # Move
-  waitFor wd.mv(path = "files/example.md", destination = "example.md")
+  wd.mv(path = "files/example.md", destination = "example.md")
 
-  # Moving again will fail because it already exists
+  # Moving again fails: the source no longer exists
   doAssertRaises(OperationFailed):
-    waitFor wd.mv(path = "files/example.md", destination = "example.md")
+    wd.mv(path = "files/example.md", destination = "example.md")
 
   # Copy
-  waitFor wd.cp(path = "example.md", destination = "files/example.md")
+  wd.cp(path = "example.md", destination = "files/example.md")
 
-  # Already exists
+  # Copying again fails: destination exists and overwrite is off
   doAssertRaises(OperationFailed):
-    waitFor wd.cp(path = "example.md", destination = "files/example.md")
+    wd.cp(path = "example.md", destination = "files/example.md")
 
   # Get possible props
-  let props = waitFor wd.props(
-    "/",
-  )
+  let props = wd.props("/")
 
   assert "supportedlock" in props["/"]
   assert "lockdiscovery" in props["/"]
   assert "getcontenttype" in props["/"]
 
   # List
-  let dir1 = waitFor wd.ls(
+  let dir1 = wd.ls(
     "/",
-    some(@[
+    @[
       "getcontentlength",
       "getlastmodified",
       "creationdate",
       "getcontenttype",
-    ]),
+    ],
     depth = ONE
   )
 
@@ -89,9 +90,9 @@ This is an example file.
   assert dir1.hasKey("/files/")
   assert dir1.hasKey("/example.md")
 
-  # Follow redirects
-  let dir2 = waitFor wd.ls(
-    "/files", # server will ask to redirect to /files/
+  # Follow redirects (server redirects /files -> /files/)
+  let dir2 = wd.ls(
+    "/files",
     depth = ONE
   )
 
@@ -99,10 +100,12 @@ This is an example file.
   assert dir2.hasKey("/files/example.md")
 
   # Delete
-  waitFor wd.rm("example.md")
-  waitFor wd.rm("files/example.md")
-  waitFor wd.rm("files/")
+  wd.rm("example.md")
+  wd.rm("files/example.md")
+  wd.rm("files/")
 
   # Does not exist
   doAssertRaises(OperationFailed):
-    waitFor wd.rm("example.md")
+    wd.rm("example.md")
+
+  echo "All integration tests passed."

--- a/webdavclient.nimble
+++ b/webdavclient.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.0"
+version       = "0.2.0"
 author        = "Beshr Kayali"
 description   = "WebDAV Client for Nim"
 license       = "MIT"
@@ -10,4 +10,16 @@ srcDir        = "src"
 
 # Dependencies
 
-requires "nim >= 1.0.0"
+requires "nim >= 2.0.0"
+requires "puppy >= 2.0.0"
+# Note: on Linux, puppy uses libcurl (install e.g. libcurl4-openssl-dev).
+# macOS and Windows use the native HTTP stack and need no extra dependency.
+
+
+# Tasks
+
+task test, "Run the unit tests (no server required)":
+  exec "nim r --hints:off tests/test_parsing.nim"
+
+task integration, "Run the integration tests against a live WebDAV server":
+  exec "nim r --hints:off tests/test_webdav.nim"


### PR DESCRIPTION
`std/httpclient` on modern Nim rejects WebDAV's custom verbs (`PROPFIND`, `MKCOL`, `MOVE`, `COPY`) with "Invalid HTTP method name" before any network call because the HttpMethod enum has no WebDAV verbs and there's no public API to send a custom one. This broke ls/props/mkdir/mv/cp on Nim >= ~1.6 (#7) .

This PR switches the transport to puppy which sends arbitrary verbs and handles TLS/redirects via the OS HTTP stack. puppy is synchronous, so the client is now synchronous too (BREAKING change).